### PR TITLE
Update tips.

### DIFF
--- a/docs/start-db-package-tutorial.md
+++ b/docs/start-db-package-tutorial.md
@@ -180,5 +180,6 @@ Operations may differ on different distributions.
 ## TIPS
 
 1. It is recommended to drop all containers and restart them before every test.
-2. If there is any network problem during synchronization of maven repositories or docker images, please delete the cache and retry.
-3. Administrator privilege is needed for editing the hosts file.
+2. Please disable your network proxy tool before packaging.
+3. If there is any network problem during synchronization of maven repositories or docker images, please delete the cache and retry.
+4. Administrator privilege is needed for editing the hosts file.


### PR DESCRIPTION
@IrisLoveLeo 今天测试的时候意外发现网络代理工具会造成start-db-server的测试出错，目前暂时定论是start-db-server的测试会扫描本地端口并尝试连接，当试图连接到代理工具的代理端口时会因为无response而造成测试failed